### PR TITLE
fix(Prefab): ensure combined rotation axes are continuously processed

### DIFF
--- a/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
+++ b/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
@@ -1,5 +1,124 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &409459189137677084
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1566159398904945297}
+  - component: {fileID: 1839560245632031899}
+  - component: {fileID: 8284354680044562093}
+  - component: {fileID: 5454229425696500266}
+  m_Layer: 0
+  m_Name: AliasRotationMomentProcesses
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1566159398904945297
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409459189137677084}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2764921036721442811}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1839560245632031899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409459189137677084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 378ecdf468e07574db371a118cd2c5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  processes: {fileID: 8284354680044562093}
+--- !u!114 &8284354680044562093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409459189137677084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  currentIndex: 0
+  elements:
+  - {fileID: 5951754865924904637}
+  - {fileID: 5951754864646203339}
+  - {fileID: 5951754865384492332}
+--- !u!114 &5454229425696500266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409459189137677084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 1839560245632031899}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0
 --- !u!1 &2764921036164915416
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,7 +381,6 @@ Transform:
   - {fileID: 698268752290028842}
   - {fileID: 698268753310788700}
   - {fileID: 698268753914922683}
-  - {fileID: 2764921038142837910}
   m_Father: {fileID: 2764921037532396202}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1540,6 +1658,8 @@ Transform:
   - {fileID: 2764921036395346708}
   - {fileID: 2764921037532396202}
   - {fileID: 2764921036797009340}
+  - {fileID: 2764921038142837910}
+  - {fileID: 1566159398904945297}
   - {fileID: 2764921037587283149}
   m_Father: {fileID: 2764921037832162239}
   m_RootOrder: 2
@@ -3446,7 +3566,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2764921036721442811}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2764921037587283147
 MonoBehaviour:
@@ -3518,6 +3638,7 @@ MonoBehaviour:
   elements:
   - {fileID: 2764921038095160118}
   - {fileID: 2764921038142837911}
+  - {fileID: 5454229425696500266}
 --- !u!1 &2764921037608323573
 GameObject:
   m_ObjectHideFlags: 0
@@ -4813,7 +4934,7 @@ GameObject:
   - component: {fileID: 2764921038142837908}
   - component: {fileID: 2764921038142837911}
   m_Layer: 0
-  m_Name: AliasMomentProcesses
+  m_Name: AliasMovementMomentProcesses
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4830,7 +4951,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2764921036221549690}
+  m_Father: {fileID: 2764921036721442811}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2764921038142837909
@@ -5556,15 +5677,15 @@ PrefabInstance:
       propertyPath: movementVerticalAxis
       value: 
       objectReference: {fileID: 2764921036166086549}
-    - target: {fileID: 8414439947269734977, guid: 2bfd973cbb1ea4446b730a74e00aee86,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5300870660688037980, guid: 2bfd973cbb1ea4446b730a74e00aee86,
         type: 3}
       propertyPath: mutateOnAxis.yState
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8414439947269734977, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bfd973cbb1ea4446b730a74e00aee86, type: 3}
@@ -5580,6 +5701,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2764921036783129854}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5951754865924904637 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8414439947269734979, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921036783129854}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3903884234494991356 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1185461618677698306, guid: 2bfd973cbb1ea4446b730a74e00aee86,
@@ -5671,16 +5804,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10443457844c6e54ca0dd75273bb9a66, type: 3}
---- !u!114 &1123845701830561661 stripped
+--- !u!114 &4031670126712423474 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3010175583744008366, guid: 10443457844c6e54ca0dd75273bb9a66,
+  m_CorrespondingSourceObject: {fileID: 1273858532996279265, guid: 10443457844c6e54ca0dd75273bb9a66,
     type: 3}
   m_PrefabInstance: {fileID: 2764921037017083859}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 24f782494a9252d49a470301a5b749ad, type: 3}
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &2028321494031733428 stripped
@@ -5695,16 +5828,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4031670126712423474 stripped
+--- !u!114 &1123845701830561661 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1273858532996279265, guid: 10443457844c6e54ca0dd75273bb9a66,
+  m_CorrespondingSourceObject: {fileID: 3010175583744008366, guid: 10443457844c6e54ca0dd75273bb9a66,
     type: 3}
   m_PrefabInstance: {fileID: 2764921037017083859}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Script: {fileID: 11500000, guid: 24f782494a9252d49a470301a5b749ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!4 &617876965370529584 stripped
@@ -5939,7 +6072,7 @@ PrefabInstance:
     - target: {fileID: 8414439947269734977, guid: 2bfd973cbb1ea4446b730a74e00aee86,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8308416853432645679, guid: 2bfd973cbb1ea4446b730a74e00aee86,
         type: 3}
@@ -5948,6 +6081,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bfd973cbb1ea4446b730a74e00aee86, type: 3}
+--- !u!1 &698268753914922677 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921037323538287}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &698268753914922683 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3453775701796587988, guid: 2bfd973cbb1ea4446b730a74e00aee86,
@@ -5966,12 +6105,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &698268753914922677 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+--- !u!114 &5951754865384492332 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8414439947269734979, guid: 2bfd973cbb1ea4446b730a74e00aee86,
     type: 3}
   m_PrefabInstance: {fileID: 2764921037323538287}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2764921037927622024
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6077,7 +6222,7 @@ PrefabInstance:
     - target: {fileID: 8414439947269734977, guid: 2bfd973cbb1ea4446b730a74e00aee86,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bfd973cbb1ea4446b730a74e00aee86, type: 3}
@@ -6093,6 +6238,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2764921037927622024}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5951754864646203339 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8414439947269734979, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921037927622024}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3903884235773766282 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1185461618677698306, guid: 2bfd973cbb1ea4446b730a74e00aee86,


### PR DESCRIPTION
The movement axes are passed to a moment processor so they are
continually processed each frame to ensure the button press keeps
moving the avatar even when the button is still being held down.

This concept has now also been applied to the rotational combined
actions as they were only picking up immediate changes in the input
which worked fine when the mouse was the input type but meant that
using an xbox controller for rotational input left the movement
jerky because it would only move when the axis value changed.