### PR TITLE
fix(Facade): remove isPlaying check from change handler

### DIFF
--- a/Runtime/SharedResources/Scripts/ObjectControllerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/ObjectControllerConfigurator.cs
@@ -124,11 +124,6 @@
         [CalledAfterChangeOf(nameof(FacingSource))]
         protected virtual void OnAfterFacingSourceChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             PositionMutator.FacingDirection = FacingSource;
         }
 
@@ -138,11 +133,6 @@
         [CalledAfterChangeOf(nameof(RotationHorizontalAxis))]
         protected virtual void OnAfterRotationHorizontalAxisChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             InternalRotationHorizontalAxis.ClearSources();
             if (RotationHorizontalAxis != null)
             {
@@ -156,11 +146,6 @@
         [CalledAfterChangeOf(nameof(RotationVerticalAxis))]
         protected virtual void OnAfterRotationVerticalAxisChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             InternalRotationVerticalAxis.ClearSources();
             if (RotationVerticalAxis != null)
             {
@@ -174,11 +159,6 @@
         [CalledAfterChangeOf(nameof(MovementHorizontalAxis))]
         protected virtual void OnAfterMovementHorizontalAxisChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             InternalMovementHorizontalAxis.ClearSources();
             if (MovementHorizontalAxis != null)
             {
@@ -192,11 +172,6 @@
         [CalledAfterChangeOf(nameof(MovementVerticalAxis))]
         protected virtual void OnAfterMovementVerticalAxisChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             InternalMovementVerticalAxis.ClearSources();
             if (MovementVerticalAxis != null)
             {

--- a/Runtime/SharedResources/Scripts/TransformPropertyResetter.cs
+++ b/Runtime/SharedResources/Scripts/TransformPropertyResetter.cs
@@ -80,11 +80,6 @@
         [CalledAfterChangeOf(nameof(Target))]
         protected virtual void OnAfterTargetChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             CacheTransformData();
         }
     }


### PR DESCRIPTION
There was an issue with Malimbe where change handler properties
were running at edit time which would cause issues with the setup
of the prefab. The original solution was to add in an isPlaying
check to prevent this. A Malimbe fix has now been pushed so the
latest version of Zinnia now contains the fix in Malimbe and therefore
this check is now no longer required.