### PR TITLE
fix(Materials): update material to new shader repo version

### DIFF
--- a/Runtime/SharedResources/Materials/LeftControllerGlass.mat
+++ b/Runtime/SharedResources/Materials/LeftControllerGlass.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: LeftControllerGlass
-  m_Shader: {fileID: 4800000, guid: 188b87425601bc14084add288ff0fa25, type: 3}
+  m_Shader: {fileID: 4800000, guid: 97e2b193aea330c42b7faae02c795a9a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Runtime/SharedResources/Materials/RightControllerGlass.mat
+++ b/Runtime/SharedResources/Materials/RightControllerGlass.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: RightControllerGlass
-  m_Shader: {fileID: 4800000, guid: 188b87425601bc14084add288ff0fa25, type: 3}
+  m_Shader: {fileID: 4800000, guid: 97e2b193aea330c42b7faae02c795a9a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0


### PR DESCRIPTION
The materials that were pointing to the once included shaders have
been updated to point to the shaders that are included in the shader
package.