### PR TITLE
fix(Prefab): set middle mouse button to correct key code

### DIFF
--- a/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
+++ b/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
@@ -3486,7 +3486,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  keyCode: 326
+  keyCode: 325
 --- !u!114 &2764921037553103432
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The Button3 button was set to the wrong key code at Mouse 3 instead of
Mouse 2, which is in fact the middle mouse button key binding.