### PR TITLE
fix(package.json): include namespace in package name

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -32,7 +32,7 @@ The `CameraRigs.SpatialSimulator` prefab provides a simulated spatial camera rig
 * Adjust the [project manifest file][Project-Manifest] `manifest.json` in a text editor.
   * Ensure `https://registry.npmjs.org/` is part of `scopedRegistries`.
     * Ensure `io.extendreality` is part of `scopes`.
-  * Add `io.extendreality.tilia.spatialsimulator.unity` to `dependencies`, stating the latest version.
+  * Add `io.extendreality.tilia.camerarigs.spatialsimulator.unity` to `dependencies`, stating the latest version.
 
   A minimal example ends up looking like this. Please note that the version `X.Y.Z` stated here is to be replaced with [the latest released version][Latest-Release] which is currently [![Release][Version-Release]][Releases].
   ```json
@@ -47,7 +47,7 @@ The `CameraRigs.SpatialSimulator` prefab provides a simulated spatial camera rig
       }
     ],
     "dependencies": {
-      "io.extendreality.tilia.spatialsimulator.unity": "X.Y.Z",
+      "io.extendreality.tilia.camerarigs.spatialsimulator.unity": "X.Y.Z",
       ...
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "io.extendreality.tilia.spatialsimulator.unity",
+    "name": "io.extendreality.tilia.camerarigs.spatialsimulator.unity",
     "displayName": "Tilia CameraRigs SpatialSimulator Unity",
     "description": "A camera rig prefab that simulates spatial hardware for the Unity software.",
     "version": "1.1.12",


### PR DESCRIPTION
The package name was missing the CameraRigs namespace which should
be included as is with all other Tilia packages.

This has now been added and the installation guide has been updated
to reflect this change.