### PR TITLE
fix(Configurator): remove application is playing checks

### DIFF
--- a/Runtime/SharedResources/Scripts/SpatialSimulatorConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/SpatialSimulatorConfigurator.cs
@@ -48,11 +48,6 @@
         [RequiresBehaviourState, CalledAfterChangeOf(nameof(XREnabled))]
         protected virtual void OnAfterXREnabledChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             XRSettings.enabled = XREnabled;
         }
 
@@ -62,11 +57,6 @@
         [RequiresBehaviourState, CalledAfterChangeOf(nameof(SimulatedFrameRate))]
         protected virtual void OnAfterSimulatedFrameRateChange()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             Time.fixedDeltaTime = Time.timeScale / SimulatedFrameRate;
         }
     }


### PR DESCRIPTION
These checks were added when there was a problem with the
BehaviourChange Malimbe methods, but this has long been fixed so
the BehaviourChange methods only ever execute when the application
is playing.