### PR TITLE
feat(prefab): add device details about headset and controllers

### DIFF
--- a/Documentation/API/ObjectControllerConfigurator.md
+++ b/Documentation/API/ObjectControllerConfigurator.md
@@ -11,11 +11,13 @@ Provides a way to configure settings related to the Object Controller prefab.
   * [FacingSource]
   * [InternalMovementHorizontalAxis]
   * [InternalMovementVerticalAxis]
+  * [InternalRotationCircularAxis]
   * [InternalRotationHorizontalAxis]
   * [InternalRotationVerticalAxis]
   * [MovementHorizontalAxis]
   * [MovementVerticalAxis]
   * [PositionMutator]
+  * [RotationCircularAxis]
   * [RotationHorizontalAxis]
   * [RotationMutator]
   * [RotationVerticalAxis]
@@ -24,6 +26,7 @@ Provides a way to configure settings related to the Object Controller prefab.
   * [OnAfterFacingSourceChange()]
   * [OnAfterMovementHorizontalAxisChange()]
   * [OnAfterMovementVerticalAxisChange()]
+  * [OnAfterRotationCircularAxisChange()]
   * [OnAfterRotationHorizontalAxisChange()]
   * [OnAfterRotationVerticalAxisChange()]
   * [OnAfterTargetChange()]
@@ -78,6 +81,16 @@ The internal FloatAction that controls the vertical movement values.
 public FloatAction InternalMovementVerticalAxis { get; set; }
 ```
 
+#### InternalRotationCircularAxis
+
+The internal FloatAction that controls the circular rotation values.
+
+##### Declaration
+
+```
+public FloatAction InternalRotationCircularAxis { get; set; }
+```
+
 #### InternalRotationHorizontalAxis
 
 The internal FloatAction that controls the horizontal rotation values.
@@ -126,6 +139,16 @@ The TransformPositionMutator that applies the movement to the [Target].
 
 ```
 public TransformPositionMutator PositionMutator { get; protected set; }
+```
+
+#### RotationCircularAxis
+
+The circular axis that controls the rotation of the [Target].
+
+##### Declaration
+
+```
+public FloatAction RotationCircularAxis { get; set; }
 ```
 
 #### RotationHorizontalAxis
@@ -200,6 +223,16 @@ Called after [MovementVerticalAxis] has been changed.
 protected virtual void OnAfterMovementVerticalAxisChange()
 ```
 
+#### OnAfterRotationCircularAxisChange()
+
+Called after [RotationCircularAxis] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterRotationCircularAxisChange()
+```
+
 #### OnAfterRotationHorizontalAxisChange()
 
 Called after [RotationHorizontalAxis] has been changed.
@@ -245,9 +278,11 @@ protected virtual void OnEnable()
 [Target]: ObjectControllerConfigurator.md#Target
 [Target]: ObjectControllerConfigurator.md#Target
 [Target]: ObjectControllerConfigurator.md#Target
+[Target]: ObjectControllerConfigurator.md#Target
 [FacingSource]: ObjectControllerConfigurator.md#FacingSource
 [MovementHorizontalAxis]: ObjectControllerConfigurator.md#MovementHorizontalAxis
 [MovementVerticalAxis]: ObjectControllerConfigurator.md#MovementVerticalAxis
+[RotationCircularAxis]: ObjectControllerConfigurator.md#RotationCircularAxis
 [RotationHorizontalAxis]: ObjectControllerConfigurator.md#RotationHorizontalAxis
 [RotationVerticalAxis]: ObjectControllerConfigurator.md#RotationVerticalAxis
 [Target]: ObjectControllerConfigurator.md#Target
@@ -258,11 +293,13 @@ protected virtual void OnEnable()
 [FacingSource]: #FacingSource
 [InternalMovementHorizontalAxis]: #InternalMovementHorizontalAxis
 [InternalMovementVerticalAxis]: #InternalMovementVerticalAxis
+[InternalRotationCircularAxis]: #InternalRotationCircularAxis
 [InternalRotationHorizontalAxis]: #InternalRotationHorizontalAxis
 [InternalRotationVerticalAxis]: #InternalRotationVerticalAxis
 [MovementHorizontalAxis]: #MovementHorizontalAxis
 [MovementVerticalAxis]: #MovementVerticalAxis
 [PositionMutator]: #PositionMutator
+[RotationCircularAxis]: #RotationCircularAxis
 [RotationHorizontalAxis]: #RotationHorizontalAxis
 [RotationMutator]: #RotationMutator
 [RotationVerticalAxis]: #RotationVerticalAxis
@@ -271,6 +308,7 @@ protected virtual void OnEnable()
 [OnAfterFacingSourceChange()]: #OnAfterFacingSourceChange
 [OnAfterMovementHorizontalAxisChange()]: #OnAfterMovementHorizontalAxisChange
 [OnAfterMovementVerticalAxisChange()]: #OnAfterMovementVerticalAxisChange
+[OnAfterRotationCircularAxisChange()]: #OnAfterRotationCircularAxisChange
 [OnAfterRotationHorizontalAxisChange()]: #OnAfterRotationHorizontalAxisChange
 [OnAfterRotationVerticalAxisChange()]: #OnAfterRotationVerticalAxisChange
 [OnAfterTargetChange()]: #OnAfterTargetChange

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -10,6 +10,10 @@ Manages the state of the mouse cursor.
 
 Provides a way to configure settings related to the Object Controller prefab.
 
+#### [SimulatorNodeRecord]
+
+Provides the description for a Simulated CameraRig node element.
+
 #### [SpatialSimulatorConfigurator]
 
 Provides a way to configure settings related to the Spatial Simulator prefab.
@@ -20,5 +24,6 @@ Resets the saved properties of a given transform.
 
 [MouseCursorManager]: MouseCursorManager.md
 [ObjectControllerConfigurator]: ObjectControllerConfigurator.md
+[SimulatorNodeRecord]: SimulatorNodeRecord.md
 [SpatialSimulatorConfigurator]: SpatialSimulatorConfigurator.md
 [TransformPropertyResetter]: TransformPropertyResetter.md

--- a/Documentation/API/SimulatorNodeRecord.md
+++ b/Documentation/API/SimulatorNodeRecord.md
@@ -1,0 +1,384 @@
+# Class SimulatorNodeRecord
+
+Provides the description for a Simulated CameraRig node element.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+  * [defaultPriority]
+  * [lastKnownBatteryStatus]
+  * [lastKnownIsConnected]
+  * [lastKnownTrackingType]
+* [Properties]
+  * [BatteryChargeStatus]
+  * [BatteryLevel]
+  * [IsConnected]
+  * [Manufacturer]
+  * [Model]
+  * [Priority]
+  * [ReferenceSource]
+  * [SimulatedBatteryChargeStatus]
+  * [SimulatedBatteryLevel]
+  * [SimulatedIsConnected]
+  * [SimulatedManufacturer]
+  * [SimulatedModel]
+  * [SimulatedNodeType]
+  * [SimulatedPriority]
+  * [SimulatedTrackingType]
+  * [TrackingType]
+  * [XRNodeType]
+* [Methods]
+  * [HasBatteryChargeStatusChanged()]
+  * [HasIsConnectedChanged()]
+  * [HasTrackingTypeChanged()]
+  * [SetBatteryChargeStatus(Int32)]
+  * [SetSimulatedNodeType(Int32)]
+  * [SetSimulatedTrackingType(Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* SimulatorNodeRecord
+
+##### Namespace
+
+* [Tilia.CameraRigs.SpatialSimulator]
+
+##### Syntax
+
+```
+public class SimulatorNodeRecord : DeviceDetailsRecord
+```
+
+### Fields
+
+#### defaultPriority
+
+The default priority to set the simulated priority to.
+
+##### Declaration
+
+```
+protected const int defaultPriority = 1000
+```
+
+#### lastKnownBatteryStatus
+
+The last known battery charge status.
+
+##### Declaration
+
+```
+protected BatteryStatus lastKnownBatteryStatus
+```
+
+#### lastKnownIsConnected
+
+The last known is connected status.
+
+##### Declaration
+
+```
+protected bool lastKnownIsConnected
+```
+
+#### lastKnownTrackingType
+
+The last known tracking type.
+
+##### Declaration
+
+```
+protected SpatialTrackingType lastKnownTrackingType
+```
+
+### Properties
+
+#### BatteryChargeStatus
+
+##### Declaration
+
+```
+public override BatteryStatus BatteryChargeStatus { get; protected set; }
+```
+
+#### BatteryLevel
+
+##### Declaration
+
+```
+public override float BatteryLevel { get; protected set; }
+```
+
+#### IsConnected
+
+##### Declaration
+
+```
+public override bool IsConnected { get; protected set; }
+```
+
+#### Manufacturer
+
+##### Declaration
+
+```
+public override string Manufacturer { get; protected set; }
+```
+
+#### Model
+
+##### Declaration
+
+```
+public override string Model { get; protected set; }
+```
+
+#### Priority
+
+##### Declaration
+
+```
+public override int Priority { get; protected set; }
+```
+
+#### ReferenceSource
+
+The source reference GameObject to determine priority from.
+
+##### Declaration
+
+```
+public GameObject ReferenceSource { get; set; }
+```
+
+#### SimulatedBatteryChargeStatus
+
+The simulated battery level.
+
+##### Declaration
+
+```
+public BatteryStatus SimulatedBatteryChargeStatus { get; set; }
+```
+
+#### SimulatedBatteryLevel
+
+The simulated battery level.
+
+##### Declaration
+
+```
+public float SimulatedBatteryLevel { get; set; }
+```
+
+#### SimulatedIsConnected
+
+The simulated connection status.
+
+##### Declaration
+
+```
+public bool SimulatedIsConnected { get; set; }
+```
+
+#### SimulatedManufacturer
+
+The simulated manufacturer name.
+
+##### Declaration
+
+```
+public string SimulatedManufacturer { get; set; }
+```
+
+#### SimulatedModel
+
+The simulated model name.
+
+##### Declaration
+
+```
+public string SimulatedModel { get; set; }
+```
+
+#### SimulatedNodeType
+
+The source property to match against.
+
+##### Declaration
+
+```
+public XRNode SimulatedNodeType { get; set; }
+```
+
+#### SimulatedPriority
+
+The simulated controller priority.
+
+##### Declaration
+
+```
+public int SimulatedPriority { get; set; }
+```
+
+#### SimulatedTrackingType
+
+The simulated tracking type.
+
+##### Declaration
+
+```
+public SpatialTrackingType SimulatedTrackingType { get; set; }
+```
+
+#### TrackingType
+
+##### Declaration
+
+```
+public override SpatialTrackingType TrackingType { get; protected set; }
+```
+
+#### XRNodeType
+
+##### Declaration
+
+```
+public override XRNode XRNodeType { get; protected set; }
+```
+
+### Methods
+
+#### HasBatteryChargeStatusChanged()
+
+##### Declaration
+
+```
+protected override bool HasBatteryChargeStatusChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### HasIsConnectedChanged()
+
+##### Declaration
+
+```
+protected override bool HasIsConnectedChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### HasTrackingTypeChanged()
+
+##### Declaration
+
+```
+protected override bool HasTrackingTypeChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### SetBatteryChargeStatus(Int32)
+
+Sets the [BatteryChargeStatus].
+
+##### Declaration
+
+```
+public virtual void SetBatteryChargeStatus(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the BatteryStatus. |
+
+#### SetSimulatedNodeType(Int32)
+
+Sets the [SimulatedNodeType].
+
+##### Declaration
+
+```
+public virtual void SetSimulatedNodeType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the XRNode. |
+
+#### SetSimulatedTrackingType(Int32)
+
+Sets the [SimulatedTrackingType].
+
+##### Declaration
+
+```
+public virtual void SetSimulatedTrackingType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the SpatialTrackingType. |
+
+[Tilia.CameraRigs.SpatialSimulator]: README.md
+[BatteryChargeStatus]: SimulatorNodeRecord.md#BatteryChargeStatus
+[SimulatedNodeType]: SimulatorNodeRecord.md#SimulatedNodeType
+[SimulatedTrackingType]: SimulatorNodeRecord.md#SimulatedTrackingType
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields
+[defaultPriority]: #defaultPriority
+[lastKnownBatteryStatus]: #lastKnownBatteryStatus
+[lastKnownIsConnected]: #lastKnownIsConnected
+[lastKnownTrackingType]: #lastKnownTrackingType
+[Properties]: #Properties
+[BatteryChargeStatus]: #BatteryChargeStatus
+[BatteryLevel]: #BatteryLevel
+[IsConnected]: #IsConnected
+[Manufacturer]: #Manufacturer
+[Model]: #Model
+[Priority]: #Priority
+[ReferenceSource]: #ReferenceSource
+[SimulatedBatteryChargeStatus]: #SimulatedBatteryChargeStatus
+[SimulatedBatteryLevel]: #SimulatedBatteryLevel
+[SimulatedIsConnected]: #SimulatedIsConnected
+[SimulatedManufacturer]: #SimulatedManufacturer
+[SimulatedModel]: #SimulatedModel
+[SimulatedNodeType]: #SimulatedNodeType
+[SimulatedPriority]: #SimulatedPriority
+[SimulatedTrackingType]: #SimulatedTrackingType
+[TrackingType]: #TrackingType
+[XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[HasBatteryChargeStatusChanged()]: #HasBatteryChargeStatusChanged
+[HasIsConnectedChanged()]: #HasIsConnectedChanged
+[HasTrackingTypeChanged()]: #HasTrackingTypeChanged
+[SetBatteryChargeStatus(Int32)]: #SetBatteryChargeStatusInt32
+[SetSimulatedNodeType(Int32)]: #SetSimulatedNodeTypeInt32
+[SetSimulatedTrackingType(Int32)]: #SetSimulatedTrackingTypeInt32

--- a/Documentation/API/SimulatorNodeRecord.md.meta
+++ b/Documentation/API/SimulatorNodeRecord.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ec00e1fe0674d84bbaff2536264d97c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
+++ b/Runtime/Prefabs/CameraRigs.SpatialSimulator.prefab
@@ -749,8 +749,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -762,7 +760,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -775,7 +772,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921036395346711
 GameObject:
   m_ObjectHideFlags: 0
@@ -988,7 +984,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921036850531689}
-        m_TargetAssemblyTypeName: 
         m_MethodName: Receive
         m_Mode: 6
         m_Arguments:
@@ -1000,7 +995,6 @@ MonoBehaviour:
           m_BoolArgument: 1
         m_CallState: 2
       - m_Target: {fileID: 2764921036850531689}
-        m_TargetAssemblyTypeName: 
         m_MethodName: Receive
         m_Mode: 6
         m_Arguments:
@@ -1131,10 +1125,9 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -1802,7 +1795,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921036850531702}
-        m_TargetAssemblyTypeName: 
         m_MethodName: Receive
         m_Mode: 0
         m_Arguments:
@@ -1844,7 +1836,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921036797009341}
-        m_TargetAssemblyTypeName: 
         m_MethodName: set_Locked
         m_Mode: 0
         m_Arguments:
@@ -1865,7 +1856,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921036797009341}
-        m_TargetAssemblyTypeName: 
         m_MethodName: set_Locked
         m_Mode: 0
         m_Arguments:
@@ -1886,6 +1876,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2764921036858783399}
   - component: {fileID: 2764921036858783396}
+  - component: {fileID: 8886640283934978129}
+  - component: {fileID: 1553650751686562143}
   m_Layer: 0
   m_Name: HeadAnchor
   m_TagString: Untagged
@@ -1925,6 +1917,55 @@ MonoBehaviour:
   isEstimating: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
+--- !u!114 &8886640283934978129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921036858783398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 776eb56257d273b45891d95eb1811fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  simulatedNodeType: 3
+  simulatedIsConnected: 1
+  simulatedPriority: 1000
+  simulatedManufacturer: Tilia
+  simulatedModel: SpatialSimulatorHeadset
+  simulatedTrackingType: 3
+  simulatedBatteryLevel: -1
+  simulatedBatteryChargeStatus: 0
+  referenceSource: {fileID: 698268752290028836}
+--- !u!114 &1553650751686562143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921036858783398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 8886640283934978129}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &2764921036869593588
 GameObject:
   m_ObjectHideFlags: 0
@@ -2107,6 +2148,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2764921037088951343}
   - component: {fileID: 2764921037088951340}
+  - component: {fileID: 5655629282080041272}
+  - component: {fileID: 644869811652522181}
   m_Layer: 0
   m_Name: RightController
   m_TagString: Untagged
@@ -2146,6 +2189,55 @@ MonoBehaviour:
   isEstimating: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
+--- !u!114 &5655629282080041272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037088951342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 776eb56257d273b45891d95eb1811fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  simulatedNodeType: 5
+  simulatedIsConnected: 1
+  simulatedPriority: 1000
+  simulatedManufacturer: Tilia
+  simulatedModel: SpatialSimulatorRightController
+  simulatedTrackingType: 3
+  simulatedBatteryLevel: -1
+  simulatedBatteryChargeStatus: 0
+  referenceSource: {fileID: 698268753914922677}
+--- !u!114 &644869811652522181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037088951342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 5655629282080041272}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &2764921037158875833
 GameObject:
   m_ObjectHideFlags: 0
@@ -2264,7 +2356,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921037160163658}
-        m_TargetAssemblyTypeName: 
         m_MethodName: ResetProperties
         m_Mode: 1
         m_Arguments:
@@ -2514,6 +2605,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2764921037329734388}
   - component: {fileID: 2764921037329734389}
+  - component: {fileID: 1440710616494618670}
+  - component: {fileID: 948197101181685311}
   m_Layer: 0
   m_Name: LeftController
   m_TagString: Untagged
@@ -2553,6 +2646,55 @@ MonoBehaviour:
   isEstimating: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
+--- !u!114 &1440710616494618670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037329734391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 776eb56257d273b45891d95eb1811fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  simulatedNodeType: 4
+  simulatedIsConnected: 1
+  simulatedPriority: 1000
+  simulatedManufacturer: Tilia
+  simulatedModel: SpatialSimulatorLeftController
+  simulatedTrackingType: 3
+  simulatedBatteryLevel: -1
+  simulatedBatteryChargeStatus: 0
+  referenceSource: {fileID: 698268753310788690}
+--- !u!114 &948197101181685311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037329734391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 1440710616494618670}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &2764921037332774328
 GameObject:
   m_ObjectHideFlags: 0
@@ -2607,7 +2749,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
         m_MethodName: 
         m_Mode: 1
         m_Arguments:
@@ -2777,7 +2918,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 698268752290028836}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -2789,7 +2929,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 698268753310788690}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -2801,7 +2940,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 698268753914922677}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -3194,7 +3332,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921038133101275}
-        m_TargetAssemblyTypeName: 
         m_MethodName: Receive
         m_Mode: 6
         m_Arguments:
@@ -3206,7 +3343,6 @@ MonoBehaviour:
           m_BoolArgument: 1
         m_CallState: 2
       - m_Target: {fileID: 2764921038133101275}
-        m_TargetAssemblyTypeName: 
         m_MethodName: Receive
         m_Mode: 6
         m_Arguments:
@@ -3546,8 +3682,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -3559,7 +3693,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3572,7 +3705,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921037616039675
 GameObject:
   m_ObjectHideFlags: 0
@@ -3627,7 +3759,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 698268752290028836}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -3639,7 +3770,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 698268753310788690}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -3651,7 +3781,6 @@ MonoBehaviour:
           m_BoolArgument: 1
         m_CallState: 2
       - m_Target: {fileID: 698268753914922677}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -3853,8 +3982,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -3866,7 +3993,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3879,7 +4005,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921037717192440
 GameObject:
   m_ObjectHideFlags: 0
@@ -3934,8 +4059,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -3947,7 +4070,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3960,7 +4082,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921037764554994
 GameObject:
   m_ObjectHideFlags: 0
@@ -4066,6 +4187,8 @@ GameObject:
   - component: {fileID: 2764921037832162239}
   - component: {fileID: 2764921037832162237}
   - component: {fileID: 2764921037832162236}
+  - component: {fileID: 5175617897564888778}
+  - component: {fileID: 6642407473837415707}
   m_Layer: 0
   m_Name: CameraRigs.SpatialSimulator
   m_TagString: Untagged
@@ -4087,6 +4210,7 @@ Transform:
   - {fileID: 2764921037399709303}
   - {fileID: 2764921036276158785}
   - {fileID: 2764921036721442811}
+  - {fileID: 5779802035964741130}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4121,14 +4245,51 @@ MonoBehaviour:
   headsetCamera: {fileID: 2764921036518390055}
   headsetVelocityTracker: {fileID: 2764921036858783396}
   supplementHeadsetCameras: {fileID: 0}
+  headsetDeviceDetails: {fileID: 8886640283934978129}
+  dominantController: {fileID: 5175617897564888778}
   leftController: {fileID: 2764921037329734391}
   leftControllerVelocityTracker: {fileID: 2764921037329734389}
   leftControllerHapticProcess: {fileID: 0}
   leftControllerHapticProfiles: {fileID: 0}
+  leftControllerDeviceDetails: {fileID: 1440710616494618670}
   rightController: {fileID: 2764921037088951342}
   rightControllerVelocityTracker: {fileID: 2764921037088951340}
   rightControllerHapticProcess: {fileID: 0}
   rightControllerHapticProfiles: {fileID: 0}
+  rightControllerDeviceDetails: {fileID: 5655629282080041272}
+--- !u!114 &5175617897564888778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037832162238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7512583a373897b4aa8971c27e3264cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leftController: {fileID: 1440710616494618670}
+  rightController: {fileID: 5655629282080041272}
+  IsChanging:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6642407473837415707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764921037832162238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 5175617897564888778}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &2764921037878037797
 GameObject:
   m_ObjectHideFlags: 0
@@ -4529,8 +4690,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -4542,7 +4701,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4555,7 +4713,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921038120827352
 GameObject:
   m_ObjectHideFlags: 0
@@ -4610,8 +4767,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -4623,7 +4778,6 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4636,7 +4790,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2764921038132344238
 GameObject:
   m_ObjectHideFlags: 0
@@ -4724,7 +4877,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 698268752290028836}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -4736,7 +4888,6 @@ MonoBehaviour:
           m_BoolArgument: 1
         m_CallState: 2
       - m_Target: {fileID: 698268753310788690}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -4748,7 +4899,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 698268753914922677}
-        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -5322,7 +5472,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2764921036937084573}
-        m_TargetAssemblyTypeName: 
         m_MethodName: ResetProperties
         m_Mode: 1
         m_Arguments:
@@ -5334,7 +5483,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 2764921038167632805}
-        m_TargetAssemblyTypeName: 
         m_MethodName: ResetProperties
         m_Mode: 1
         m_Arguments:
@@ -5387,6 +5535,128 @@ Transform:
   m_Father: {fileID: 2764921037329734388}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3232701687689825124
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5779802035964741130}
+  - component: {fileID: 8303679562209867897}
+  m_Layer: 0
+  m_Name: MomentProcessor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5779802035964741130
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3232701687689825124}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7751892149780139693}
+  m_Father: {fileID: 2764921037832162239}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8303679562209867897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3232701687689825124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  processMoment: 3
+  processes: {fileID: 1257830913464632860}
+--- !u!1 &6169941593349138392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7751892149780139693}
+  - component: {fileID: 1257830913464632860}
+  m_Layer: 0
+  m_Name: ListContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7751892149780139693
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6169941593349138392}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5779802035964741130}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1257830913464632860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6169941593349138392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 6642407473837415707}
+  - {fileID: 1553650751686562143}
+  - {fileID: 948197101181685311}
+  - {fileID: 644869811652522181}
 --- !u!1001 &2764921036783129854
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5506,24 +5776,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bfd973cbb1ea4446b730a74e00aee86, type: 3}
---- !u!1 &698268752290028836 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
-    type: 3}
-  m_PrefabInstance: {fileID: 2764921036783129854}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3903884234494991356 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1185461618677698306, guid: 2bfd973cbb1ea4446b730a74e00aee86,
-    type: 3}
-  m_PrefabInstance: {fileID: 2764921036783129854}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &698268752175702362 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3453775701642491300, guid: 2bfd973cbb1ea4446b730a74e00aee86,
@@ -5542,6 +5794,24 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2764921036783129854}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &698268752290028836 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921036783129854}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3903884234494991356 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1185461618677698306, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921036783129854}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2764921037017083859
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5621,22 +5891,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10443457844c6e54ca0dd75273bb9a66, type: 3}
---- !u!4 &617876965370529584 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3372592331053525219, guid: 10443457844c6e54ca0dd75273bb9a66,
-    type: 3}
-  m_PrefabInstance: {fileID: 2764921037017083859}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1123845701830561661 stripped
+--- !u!114 &4031670126712423474 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3010175583744008366, guid: 10443457844c6e54ca0dd75273bb9a66,
+  m_CorrespondingSourceObject: {fileID: 1273858532996279265, guid: 10443457844c6e54ca0dd75273bb9a66,
     type: 3}
   m_PrefabInstance: {fileID: 2764921037017083859}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 24f782494a9252d49a470301a5b749ad, type: 3}
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &2028321494031733428 stripped
@@ -5651,18 +5915,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4031670126712423474 stripped
+--- !u!114 &1123845701830561661 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1273858532996279265, guid: 10443457844c6e54ca0dd75273bb9a66,
+  m_CorrespondingSourceObject: {fileID: 3010175583744008366, guid: 10443457844c6e54ca0dd75273bb9a66,
     type: 3}
   m_PrefabInstance: {fileID: 2764921037017083859}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Script: {fileID: 11500000, guid: 24f782494a9252d49a470301a5b749ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &617876965370529584 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3372592331053525219, guid: 10443457844c6e54ca0dd75273bb9a66,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921037017083859}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2764921037122392573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5923,18 +6193,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &698268753914922683 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3453775701796587988, guid: 2bfd973cbb1ea4446b730a74e00aee86,
-    type: 3}
-  m_PrefabInstance: {fileID: 2764921037323538287}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &698268753914922677 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
-    type: 3}
-  m_PrefabInstance: {fileID: 2764921037323538287}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &698268753798511307 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3453775701642491300, guid: 2bfd973cbb1ea4446b730a74e00aee86,
@@ -5947,6 +6205,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &698268753914922683 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3453775701796587988, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921037323538287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &698268753914922677 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3453775701796587994, guid: 2bfd973cbb1ea4446b730a74e00aee86,
+    type: 3}
+  m_PrefabInstance: {fileID: 2764921037323538287}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2764921037927622024
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs
@@ -1,0 +1,179 @@
+﻿namespace Tilia.CameraRigs.SpatialSimulator
+{
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
+    using UnityEngine.XR;
+    using Zinnia.Extension;
+    using Zinnia.Tracking.CameraRig;
+
+    /// <summary>
+    /// Provides the description for a Simulated CameraRig node element.
+    /// </summary>
+    public class SimulatorNodeRecord : DeviceDetailsRecord
+    {
+        /// <summary>
+        /// The source property to match against.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public XRNode SimulatedNodeType { get; set; }
+        /// <summary>
+        /// The simulated connection status.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool SimulatedIsConnected { get; set; } = true;
+        /// <summary>
+        /// The simulated controller priority.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public int SimulatedPriority { get; set; } = defaultPriority;
+        /// <summary>
+        /// The simulated manufacturer name.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public string SimulatedManufacturer { get; set; } = "Tilia";
+        /// <summary>
+        /// The simulated model name.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public string SimulatedModel { get; set; } = "SpatialSimulator";
+        /// <summary>
+        /// The simulated tracking type.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public SpatialTrackingType SimulatedTrackingType { get; set; } = SpatialTrackingType.RotationAndPosition;
+        /// <summary>
+        /// The simulated battery level.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float SimulatedBatteryLevel { get; set; } = -1f;
+        /// <summary>
+        /// The simulated battery level.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public BatteryStatus SimulatedBatteryChargeStatus { get; set; } = BatteryStatus.Unknown;
+        /// <summary>
+        /// The source reference GameObject to determine priority from.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObject ReferenceSource { get; set; }
+
+        /// <summary>
+        /// The default priority to set the simulated priority to.
+        /// </summary>
+        protected const int defaultPriority = 1000;
+
+        /// <inheritdoc/>
+        public override XRNode XRNodeType
+        {
+            get
+            {
+                return SimulatedNodeType;
+            }
+            protected set { SimulatedNodeType = value; }
+        }
+        /// <inheritdoc/>
+        public override bool IsConnected { get => SimulatedIsConnected; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override int Priority
+        {
+            get => SimulatedPriority == defaultPriority && ReferenceSource != null && ReferenceSource.activeInHierarchy ? 0 : SimulatedPriority;
+            protected set => throw new System.NotImplementedException();
+        }
+        /// <inheritdoc/>
+        public override string Manufacturer { get => SimulatedManufacturer; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override string Model { get => SimulatedModel; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override SpatialTrackingType TrackingType { get => SimulatedTrackingType; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override float BatteryLevel { get => SimulatedBatteryLevel; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override BatteryStatus BatteryChargeStatus { get => SimulatedBatteryChargeStatus; protected set => throw new System.NotImplementedException(); }
+
+        /// <summary>
+        /// The last known battery charge status.
+        /// </summary>
+        protected BatteryStatus lastKnownBatteryStatus;
+        /// <summary>
+        /// The last known is connected status.
+        /// </summary>
+        protected bool lastKnownIsConnected;
+        /// <summary>
+        /// The last known tracking type.
+        /// </summary>
+        protected SpatialTrackingType lastKnownTrackingType;
+
+        /// <summary>
+        /// Sets the <see cref="SimulatedNodeType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="XRNode"/>.</param>
+        public virtual void SetSimulatedNodeType(int index)
+        {
+            SimulatedNodeType = EnumExtensions.GetByIndex<XRNode>(index);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="SimulatedTrackingType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="SpatialTrackingType"/>.</param>
+        public virtual void SetSimulatedTrackingType(int index)
+        {
+            SimulatedTrackingType = EnumExtensions.GetByIndex<SpatialTrackingType>(index);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="BatteryChargeStatus"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="BatteryStatus"/>.</param>
+        public virtual void SetBatteryChargeStatus(int index)
+        {
+            BatteryChargeStatus = EnumExtensions.GetByIndex<BatteryStatus>(index);
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasBatteryChargeStatusChanged()
+        {
+            bool hasChanged = BatteryChargeStatus != lastKnownBatteryStatus;
+            if (hasChanged)
+            {
+                BatteryChargeStatusChanged?.Invoke(BatteryChargeStatus);
+            }
+            lastKnownBatteryStatus = BatteryChargeStatus;
+            return hasChanged;
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasIsConnectedChanged()
+        {
+            bool hasChanged = IsConnected != lastKnownIsConnected;
+            if (hasChanged)
+            {
+                ConnectionStatusChanged?.Invoke(IsConnected);
+            }
+            lastKnownIsConnected = IsConnected;
+            return hasChanged;
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasTrackingTypeChanged()
+        {
+            bool hasChanged = TrackingType != lastKnownTrackingType;
+            if (hasChanged)
+            {
+                TrackingTypeChanged?.Invoke(TrackingType);
+            }
+            lastKnownTrackingType = TrackingType;
+            return hasChanged;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs.meta
+++ b/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 776eb56257d273b45891d95eb1811fd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new DeviceDetailsRecord has been extended into the
SimulatorNodeRecord that provide information about a simulated node
device and this is now stored on the prefab so it is easily available
at runtime.

The DominantControllerObserver has also been added to the prefab to
make it easier to determine the current dominant controller.