### PR TITLE
feat(DeviceDetails): add defaults for passthrough camera details

### DIFF
--- a/Documentation/API/SimulatorNodeRecord.md
+++ b/Documentation/API/SimulatorNodeRecord.md
@@ -12,6 +12,7 @@ Provides the description for a Simulated CameraRig node element.
 * [Properties]
   * [BatteryChargeStatus]
   * [BatteryLevel]
+  * [HasPassThroughCamera]
   * [IsConnected]
   * [Manufacturer]
   * [Model]
@@ -77,6 +78,14 @@ public override BatteryStatus BatteryChargeStatus { get; protected set; }
 
 ```
 public override float BatteryLevel { get; protected set; }
+```
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
 ```
 
 #### IsConnected
@@ -279,6 +288,7 @@ public virtual void SetSimulatedTrackingType(int index)
 [Properties]: #Properties
 [BatteryChargeStatus]: #BatteryChargeStatus
 [BatteryLevel]: #BatteryLevel
+[HasPassThroughCamera]: #HasPassThroughCamera
 [IsConnected]: #IsConnected
 [Manufacturer]: #Manufacturer
 [Model]: #Model

--- a/Documentation/HowToGuides/AddingASpatialSimulatorCameraRig/README.md
+++ b/Documentation/HowToGuides/AddingASpatialSimulatorCameraRig/README.md
@@ -58,7 +58,7 @@ Now you have a Spatial Simulator CameraRig in your scene. If you play the Unity 
 * `2` - Activate movement/rotation of the simulated Left Controller and deactivate movement/rotation of simulated PlayArea and Right Controller.
 * `3` - Activate movement/rotation of the simulated Right Controller and deactivate movement/rotation of simulated PlayArea and Left Controller.
 * `4` - Reset the position/rotation of the simulated PlayArea back to the default settings.
-* `4` - Reset the position/rotation of the simulated Controllers back to the default settings.
+* `5` - Reset the position/rotation of the simulated Controllers back to the default settings.
 * `6` - Lock/Unlock mouse cursor to Game window.
 
 > The default input settings can be mapped to external inputs such as an Xbox controller by updated the `Sources` on the relevant `Actions` found within `CameraRigs.SpatialSimulator -> Input`.

--- a/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/SimulatorNodeRecord.cs
@@ -189,6 +189,8 @@
         public override float BatteryLevel { get => SimulatedBatteryLevel; protected set => throw new System.NotImplementedException(); }
         /// <inheritdoc/>
         public override BatteryStatus BatteryChargeStatus { get => SimulatedBatteryChargeStatus; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => false; protected set => throw new System.NotImplementedException(); }
 
         /// <summary>
         /// Sets the <see cref="SimulatedNodeType"/>.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0",
+        "io.extendreality.zinnia.unity": "2.7.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.3.1",
         "io.extendreality.tilia.input.unityinputmanager": "2.0.7"
     },


### PR DESCRIPTION
The DeviceDetailsRecord now supports passthrough camera options and therefore anything that derrives from that needs to implement the base interfaces even if they don't support camera passthrough yet.