### PR TITLE
feat(Resources): update materials to use tilia shader

### DIFF
--- a/Runtime/SharedResources/Materials/LeftController.mat
+++ b/Runtime/SharedResources/Materials/LeftController.mat
@@ -4,10 +4,11 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: LeftController
-  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 97e2b193aea330c42b7faae02c795a9a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Runtime/SharedResources/Materials/RightController.mat
+++ b/Runtime/SharedResources/Materials/RightController.mat
@@ -4,10 +4,11 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: RightController
-  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 97e2b193aea330c42b7faae02c795a9a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0


### PR DESCRIPTION
The tilia unlit shader supports all current render pipelines, whereas the built in standard shader does not support SRP pipelines so would render the material as pink. Using the Tilia unlit shader means these materials will work across all pipelines.